### PR TITLE
Authenticate solvers for problem file downloads

### DIFF
--- a/psp_solver_sdk/config.py
+++ b/psp_solver_sdk/config.py
@@ -67,8 +67,8 @@ class ApiConfig:
 
 @dataclass
 class KeycloakConfig:
-    client_id: str = _env_field("KEYCLOAK_CLIENT_ID")
-    client_secret: str = _env_field("KEYCLOAK_CLIENT_SECRET")
+    client_id: str | None = _env_field("KEYCLOAK_CLIENT_ID", default=None)
+    client_secret: str | None = _env_field("KEYCLOAK_CLIENT_SECRET", default=None)
     well_known_url: str = field(default="http://user.psp.svc.cluster.local:8080/v1/internal/.well-known/openid-configuration")
 
 

--- a/psp_solver_sdk/config.py
+++ b/psp_solver_sdk/config.py
@@ -66,9 +66,17 @@ class ApiConfig:
 
 
 @dataclass
+class KeycloakConfig:
+    client_id: str = _env_field("KEYCLOAK_CLIENT_ID")
+    client_secret: str = _env_field("KEYCLOAK_CLIENT_SECRET")
+    well_known_url: str = field(default="http://user.psp.svc.cluster.local:8080/v1/internal/.well-known/openid-configuration")
+
+
+@dataclass
 class SolverConfig:
     debug: bool = _env_field("DEBUG", "false", process=lambda s: s.lower() == "true")
     service: ServiceConfig = field(default_factory=ServiceConfig)
     api: ApiConfig = field(default_factory=ApiConfig)
     cpu: CpuConfig = field(default_factory=CpuConfig)
     queue: QueueConfig = field(default_factory=QueueConfig)
+    keycloak: KeycloakConfig = field(default_factory=KeycloakConfig)

--- a/psp_solver_sdk/config.py
+++ b/psp_solver_sdk/config.py
@@ -67,8 +67,8 @@ class ApiConfig:
 
 @dataclass
 class KeycloakConfig:
-    client_id: str | None = _env_field("KEYCLOAK_CLIENT_ID", default=None)
-    client_secret: str | None = _env_field("KEYCLOAK_CLIENT_SECRET", default=None)
+    client_id: str = _env_field("KEYCLOAK_CLIENT_ID", default="")
+    client_secret: str = _env_field("KEYCLOAK_CLIENT_SECRET", default="")
     well_known_url: str = field(default="http://user.psp.svc.cluster.local:8080/v1/internal/.well-known/openid-configuration")
 
 

--- a/psp_solver_sdk/config.py
+++ b/psp_solver_sdk/config.py
@@ -68,7 +68,7 @@ class ApiConfig:
 @dataclass
 class KeycloakConfig:
     client_id: str = _env_field("KEYCLOAK_CLIENT_ID", default="")
-    client_secret: str = _env_field("KEYCLOAK_CLIENT_SECRET", default="")
+    client_secret: str = _env_field("KEYCLOAK_CLIENT_SECRET", default="")  # nosec B105
     well_known_url: str = field(default="http://user.psp.svc.cluster.local:8080/v1/internal/.well-known/openid-configuration")
 
 

--- a/psp_solver_sdk/sat/process.py
+++ b/psp_solver_sdk/sat/process.py
@@ -9,16 +9,41 @@ from .response import (
 from ..config import SolverConfig
 import httpx
 import tempfile
+import time
+
+_token_cache: dict = {"token": None, "expires_at": 0.0}
 
 
-async def _make_get_request(url: str) -> httpx.Response:
+async def _get_service_token(config: SolverConfig) -> str:
+    if _token_cache["token"] and time.time() < _token_cache["expires_at"] - 15:
+        return _token_cache["token"]
+    timeout = httpx.Timeout(5.0, connect=2.0)
+    async with httpx.AsyncClient(timeout=timeout) as http:
+        r = await http.get(config.keycloak.well_known_url)
+        r.raise_for_status()
+        token_endpoint = r.json()["token_endpoint"]
+        r = await http.post(token_endpoint, data={
+            "grant_type": "client_credentials",
+            "client_id": config.keycloak.client_id,
+            "client_secret": config.keycloak.client_secret,
+            "scope": "solver-director:problems:read",
+        })
+        r.raise_for_status()
+        data = r.json()
+        _token_cache["token"] = data["access_token"]
+        _token_cache["expires_at"] = time.time() + data.get("expires_in", 300)
+        return _token_cache["token"]
+
+
+async def _make_get_request(url: str, config: SolverConfig) -> httpx.Response:
+    token = await _get_service_token(config)
     timeout = httpx.Timeout(10.0, connect=5.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
-        return await client.get(url)
+        return await client.get(url, headers={"Authorization": f"Bearer {token}"})
 
 
-async def _get_text_from_url(url: str) -> str:
-    response = await _make_get_request(url)
+async def _get_text_from_url(url: str, config: SolverConfig) -> str:
+    response = await _make_get_request(url, config)
     return response.text
 
 
@@ -28,8 +53,8 @@ async def sat_process(
     config: SolverConfig,
 ) -> dict:
     request = SolverRequest.from_dict(data)
-    problem_bytes = await _get_text_from_url(request.problem_url)
-    instance_bytes = await _get_text_from_url(request.instance_url)
+    problem_bytes = await _get_text_from_url(request.problem_url, config)
+    instance_bytes = await _get_text_from_url(request.instance_url, config)
     with tempfile.NamedTemporaryFile(
         mode="w+", prefix="problem_", suffix=".mzn", delete=True
     ) as problem_file:

--- a/psp_solver_sdk/sat/process.py
+++ b/psp_solver_sdk/sat/process.py
@@ -11,7 +11,7 @@ import httpx
 import tempfile
 import time
 
-_token_cache: dict = {"token": None, "expires_at": 0.0}
+_token_cache: dict = {"token": None, "expires_at": 0.0}  # nosec B105
 
 
 async def _get_service_token(config: SolverConfig) -> str:

--- a/tests/sat/mocks.py
+++ b/tests/sat/mocks.py
@@ -17,7 +17,7 @@ def load_file(path: str) -> bytes:
 
 
 def mock_get_request_content(mocker, file_contents: dict[str, bytes]):
-    async def mocked_get_request(url: str) -> httpx.Response:
+    async def mocked_get_request(url: str, config) -> httpx.Response:
         if url in file_contents:
             content = file_contents[url]
             return file_response(content)

--- a/uv.lock
+++ b/uv.lock
@@ -1215,7 +1215,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1224,9 +1224,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Client credentials grant to download problem/instance files from solver-director
- Keycloak config with optional env vars (defaults to empty for backwards compat)